### PR TITLE
feat: use redis sscan instead of smembers; add scan limit config

### DIFF
--- a/core/src/main/kotlin/Config.kt
+++ b/core/src/main/kotlin/Config.kt
@@ -160,6 +160,7 @@ data class RedisConfiguration(
     val uri: String? = null,
     val readOnlyUri: String? = uri,
     val prefix: String = Default.REDIS_PREFIX,
+    val scanLimit: Long = Default.REDIS_SCAN_LIMIT,
 ) {
     companion object {
         fun fromEnv(): RedisConfiguration? {
@@ -167,10 +168,12 @@ data class RedisConfiguration(
             return if (redisUri != null) {
                 val redisReadOnlyUri = stringEnv(EnvKey.REDIS_READ_ONLY_URI, Default.REDIS_READ_ONLY_URI) ?: redisUri
                 val redisPrefix = stringEnv(EnvKey.REDIS_PREFIX, Default.REDIS_PREFIX)!!
+                val redisScanLimit = longEnv(EnvKey.REDIS_SCAN_LIMIT, Default.REDIS_SCAN_LIMIT)!!
                 RedisConfiguration(
                     uri = redisUri,
                     readOnlyUri = redisReadOnlyUri,
                     prefix = redisPrefix,
+                    scanLimit = redisScanLimit,
                 )
             } else {
                 null
@@ -204,6 +207,7 @@ object EnvKey {
     const val REDIS_URI = "AMPLITUDE_REDIS_URI"
     const val REDIS_READ_ONLY_URI = "AMPLITUDE_REDIS_READ_ONLY_URI"
     const val REDIS_PREFIX = "AMPLITUDE_REDIS_PREFIX"
+    const val REDIS_SCAN_LIMIT = "AMPLITUDE_REDIS_SCAN_LIMIT"
 }
 
 object Default {
@@ -230,6 +234,7 @@ object Default {
     val REDIS_URI: String? = null
     val REDIS_READ_ONLY_URI: String? = null
     const val REDIS_PREFIX = "amplitude"
+    const val REDIS_SCAN_LIMIT = 10000L
 }
 
 private fun getServerUrl(zone: String): String {

--- a/core/src/main/kotlin/cohort/CohortStorage.kt
+++ b/core/src/main/kotlin/cohort/CohortStorage.kt
@@ -82,7 +82,7 @@ internal fun getCohortStorage(
             redisConfiguration.prefix,
             redis,
             readOnlyRedis,
-            redisConfiguration.scanLimit
+            redisConfiguration.scanLimit,
         )
     }
 }

--- a/core/src/main/kotlin/cohort/CohortStorage.kt
+++ b/core/src/main/kotlin/cohort/CohortStorage.kt
@@ -76,7 +76,14 @@ internal fun getCohortStorage(
             } else {
                 redis
             }
-        RedisCohortStorage(projectId, ttl, redisConfiguration.prefix, redis, readOnlyRedis)
+        RedisCohortStorage(
+            projectId,
+            ttl,
+            redisConfiguration.prefix,
+            redis,
+            readOnlyRedis,
+            redisConfiguration.scanLimit
+        )
     }
 }
 
@@ -135,6 +142,7 @@ internal class RedisCohortStorage(
     private val prefix: String,
     private val redis: Redis,
     private val readOnlyRedis: Redis,
+    private val scanLimit: Long,
 ) : CohortStorage {
     companion object {
         val log by logger()
@@ -258,6 +266,6 @@ internal class RedisCohortStorage(
         cohortGroupType: String,
         cohortLastModified: Long,
     ): Set<String>? {
-        return redis.smembers(RedisKey.CohortMembers(prefix, projectId, cohortId, cohortGroupType, cohortLastModified))
+        return redis.sscan(RedisKey.CohortMembers(prefix, projectId, cohortId, cohortGroupType, cohortLastModified), scanLimit)
     }
 }

--- a/core/src/main/kotlin/project/ProjectStorage.kt
+++ b/core/src/main/kotlin/project/ProjectStorage.kt
@@ -20,7 +20,7 @@ internal fun getProjectStorage(redisConfiguration: RedisConfiguration?): Project
     return if (uri == null) {
         InMemoryProjectStorage()
     } else {
-        RedisProjectStorage(redisConfiguration.prefix, RedisConnection(uri))
+        RedisProjectStorage(redisConfiguration.prefix, RedisConnection(uri), redisConfiguration.scanLimit)
     }
 }
 
@@ -47,9 +47,10 @@ internal class InMemoryProjectStorage : ProjectStorage {
 internal class RedisProjectStorage(
     private val prefix: String,
     private val redis: Redis,
+    private val scanLimit: Long
 ) : ProjectStorage {
     override suspend fun getProjects(): Set<String> {
-        return redis.smembers(RedisKey.Projects(prefix)) ?: emptySet()
+        return redis.sscan(RedisKey.Projects(prefix), scanLimit) ?: emptySet()
     }
 
     override suspend fun putProject(projectId: String) {

--- a/core/src/main/kotlin/project/ProjectStorage.kt
+++ b/core/src/main/kotlin/project/ProjectStorage.kt
@@ -47,7 +47,7 @@ internal class InMemoryProjectStorage : ProjectStorage {
 internal class RedisProjectStorage(
     private val prefix: String,
     private val redis: Redis,
-    private val scanLimit: Long
+    private val scanLimit: Long,
 ) : ProjectStorage {
     override suspend fun getProjects(): Set<String> {
         return redis.sscan(RedisKey.Projects(prefix), scanLimit) ?: emptySet()

--- a/core/src/main/kotlin/util/Redis.kt
+++ b/core/src/main/kotlin/util/Redis.kt
@@ -145,7 +145,7 @@ internal class RedisConnection(
     }
 
     override suspend fun sscan(key: RedisKey, limit: Long): Set<String>? {
-        val exists = connection.run { type(key.value) } != "none"
+        var exists = connection.run { type(key.value) } != "none"
         if (!exists) {
             return null
         }
@@ -157,6 +157,11 @@ internal class RedisConnection(
             }
             result.addAll(cursor.values)
         } while (!cursor.isFinished)
+        exists = connection.run { type(key.value) } != "none"
+        if (!exists) {
+            // Set may expire or get deleted while the scan is in process.
+            return null
+        }
         return result
     }
 

--- a/core/src/main/kotlin/util/Redis.kt
+++ b/core/src/main/kotlin/util/Redis.kt
@@ -65,7 +65,10 @@ internal interface Redis {
         value: String,
     )
 
-    suspend fun sscan(key: RedisKey, limit: Long): Set<String>?
+    suspend fun sscan(
+        key: RedisKey,
+        limit: Long,
+    ): Set<String>?
 
     suspend fun sismember(
         key: RedisKey,
@@ -144,7 +147,10 @@ internal class RedisConnection(
         }
     }
 
-    override suspend fun sscan(key: RedisKey, limit: Long): Set<String>? {
+    override suspend fun sscan(
+        key: RedisKey,
+        limit: Long,
+    ): Set<String>? {
         var exists = connection.run { type(key.value) } != "none"
         if (!exists) {
             return null
@@ -152,9 +158,10 @@ internal class RedisConnection(
         val result = mutableSetOf<String>()
         var cursor = ScanCursor.INITIAL
         do {
-            cursor = connection.run {
-                sscan(key.value, cursor, ScanArgs().limit(limit))
-            }
+            cursor =
+                connection.run {
+                    sscan(key.value, cursor, ScanArgs().limit(limit))
+                }
             result.addAll(cursor.values)
         } while (!cursor.isFinished)
         exists = connection.run { type(key.value) } != "none"

--- a/core/src/test/kotlin/cohort/CohortStorageTest.kt
+++ b/core/src/test/kotlin/cohort/CohortStorageTest.kt
@@ -26,7 +26,7 @@ class CohortStorageTest {
     @Test
     fun `test redis`(): Unit =
         runBlocking {
-            test(RedisCohortStorage("12345", Duration.INFINITE, "amplitude ", redis, redis))
+            test(RedisCohortStorage("12345", Duration.INFINITE, "amplitude ", redis, redis, 1000))
         }
 
     private fun test(cohortStorage: CohortStorage): Unit =

--- a/core/src/test/kotlin/project/ProjectStorageTest.kt
+++ b/core/src/test/kotlin/project/ProjectStorageTest.kt
@@ -18,7 +18,7 @@ class ProjectStorageTest {
     @Test
     fun `test redis`(): Unit =
         runBlocking {
-            test(RedisProjectStorage("amplitude", InMemoryRedis()))
+            test(RedisProjectStorage("amplitude", InMemoryRedis(), 1000))
         }
 
     private fun test(storage: ProjectStorage) =

--- a/core/src/test/kotlin/test/InMemoryRedis.kt
+++ b/core/src/test/kotlin/test/InMemoryRedis.kt
@@ -38,7 +38,10 @@ internal class InMemoryRedis : Redis {
         sets.getOrPut(key.value) { mutableSetOf() }.remove(value)
     }
 
-    override suspend fun sscan(key: RedisKey, limit: Long): Set<String>? {
+    override suspend fun sscan(
+        key: RedisKey,
+        limit: Long,
+    ): Set<String>? {
         return sets[key.value]?.toSet()
     }
 

--- a/core/src/test/kotlin/test/InMemoryRedis.kt
+++ b/core/src/test/kotlin/test/InMemoryRedis.kt
@@ -38,7 +38,7 @@ internal class InMemoryRedis : Redis {
         sets.getOrPut(key.value) { mutableSetOf() }.remove(value)
     }
 
-    override suspend fun smembers(key: RedisKey): Set<String>? {
+    override suspend fun sscan(key: RedisKey, limit: Long): Set<String>? {
         return sets[key.value]?.toSet()
     }
 

--- a/service/src/main/kotlin/Server.kt
+++ b/service/src/main/kotlin/Server.kt
@@ -65,7 +65,7 @@ fun main() {
             log.info("Proxy config file not found at $proxyConfigFilePath, reading configuration from env.")
             ConfigurationFile.fromEnv()
         }
-
+    log.info("Using configuration: ${configFile.configuration}")
     /*
      * Initialize and start the evaluation proxy.
      */


### PR DESCRIPTION
Using smembers on large cohorts will take a long time and block redis

Use sscan to scan members in chunks of a configurable size.