### PR TITLE
fix: pull in eval bug fix update from evaluation-core

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ logbackVersion=1.4.6
 prometheusVersion=1.10.5
 
 # amplitude
-experimentEvaluationVersion = 2.1.0
+experimentEvaluationVersion = 2.3.0
 amplitudeAnalytics = 1.12.2
 amplitudeAnalyticsJson = 20240303
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates a core experiment evaluation dependency, which can change feature-flag/experiment decisioning at runtime despite the diff being a simple version bump.
> 
> **Overview**
> Pulls in a newer `evaluation-core` by bumping `experimentEvaluationVersion` from `2.1.0` to `2.3.0` in `gradle.properties` to pick up upstream fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d136d19699699c3d5e4c9b951aa5b69268d3f507. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->