### PR TITLE
fix: include experiment key on local-eval exposure events

### DIFF
--- a/core/src/main/kotlin/exposure/ExposureTracker.kt
+++ b/core/src/main/kotlin/exposure/ExposureTracker.kt
@@ -108,6 +108,10 @@ internal fun Exposure.toAmplitudeEvents(): List<Event> {
                 if (variant.key != null) {
                     put("[Experiment] Variant", variant.key)
                 }
+                val experimentKey = variant.metadata?.get("experimentKey") as? String
+                if (experimentKey != null) {
+                    put("[Experiment] Experiment Key", experimentKey)
+                }
                 if (variant.metadata != null) {
                     put("metadata", JSONObject(variant.metadata))
                 }

--- a/core/src/test/kotlin/exposure/ExposureTrackerTest.kt
+++ b/core/src/test/kotlin/exposure/ExposureTrackerTest.kt
@@ -56,6 +56,37 @@ class ExposureTrackerTest {
         }
 
     @Test
+    fun `test exposure includes experiment key when present in metadata`() =
+        runBlocking {
+            val context = user(userId = "user", deviceId = "device").toEvaluationContext()
+            val results =
+                mapOf(
+                    "with-exp-key" to
+                        EvaluationVariant(
+                            key = "treatment",
+                            metadata = mapOf("deployed" to true, "experimentKey" to "exp-1"),
+                        ),
+                    "without-exp-key" to
+                        EvaluationVariant(
+                            key = "on",
+                            metadata = mapOf("deployed" to true),
+                        ),
+                )
+            val exposure = Exposure(context, results)
+            val events = exposure.toAmplitudeEvents()
+
+            Assert.assertEquals(2, events.size)
+            for (event in events) {
+                val flagKey = event.eventProperties.getString("[Experiment] Flag Key")
+                if (flagKey == "with-exp-key") {
+                    Assert.assertEquals("exp-1", event.eventProperties.getString("[Experiment] Experiment Key"))
+                } else {
+                    Assert.assertFalse(event.eventProperties.has("[Experiment] Experiment Key"))
+                }
+            }
+        }
+
+    @Test
     fun `test exposure skips default variants`() =
         runBlocking {
             val context = user(userId = "user", deviceId = "device").toEvaluationContext()


### PR DESCRIPTION
## Summary

- The proxy's local-eval exposure builder (`core/src/main/kotlin/exposure/ExposureTracker.kt`) emitted `[Experiment] Flag Key`, `[Experiment] Variant`, and the `metadata` blob, but did not surface `[Experiment] Experiment Key` as a top-level event property — so proxy-emitted exposures were not run-aware when a flag is reused across multiple experiment runs.
- Fix: when `variant.metadata["experimentKey"]` is non-null, set `event.eventProperties["[Experiment] Experiment Key"]`. Additive and backwards-compatible — `metadata` blob, flag key, variant, user properties, and `insertId` are unchanged.
- Mirrors [amplitude/experiment-jvm-server#53](https://github.com/amplitude/experiment-jvm-server/pull/53) and [amplitude/experiment-node-server#83](https://github.com/amplitude/experiment-node-server/pull/83).

## Test plan

- [x] Added `test exposure includes experiment key when present in metadata` to `ExposureTrackerTest`. Asserts `[Experiment] Experiment Key == "exp-1"` for the variant carrying it and absent for the variant without it.
- [x] `./gradlew :core:test` — passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: additive event property plumbing plus a focused unit test; no changes to filtering, insertId generation, or sending behavior.
> 
> **Overview**
> Local-eval exposure events now surface `variant.metadata["experimentKey"]` as a top-level event property (`[Experiment] Experiment Key`) when present, in addition to the existing flag key/variant and `metadata` blob.
> 
> Adds a unit test to assert the property is set only for variants that include `experimentKey` in metadata and absent otherwise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a174548cca921a6136bfe7b1c3a4190ec1f5eda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->