### PR TITLE
Replace SDIFFSTORE cohort diff with streamed client-side diff

### DIFF
--- a/core/src/main/kotlin/cohort/CohortStorage.kt
+++ b/core/src/main/kotlin/cohort/CohortStorage.kt
@@ -24,6 +24,13 @@ import kotlin.time.Duration
 // Constants
 private const val REDIS_SCAN_CHUNK_SIZE: Int = 1000
 
+/**
+ * Maximum number of existing-set members held in proxy memory at once while diffing two cohort
+ * versions. Cohorts larger than this are diffed in ceil(size / limit) hash partitions, trading one
+ * extra SSCAN pass over both member sets per additional partition for bounded memory.
+ */
+private const val DIFF_PARTITION_MAX_MEMBERS: Int = 2_000_000
+
 @Serializable
 internal data class CohortDescription(
     @SerialName("cohortId") val id: String,
@@ -228,6 +235,7 @@ internal class RedisCohortStorage(
     private val scanLimit: Long,
     private val pipelineBatchSize: Int,
     private val cohortBlobCache: CohortBlobCache,
+    private val diffPartitionMaxMembers: Int = DIFF_PARTITION_MAX_MEMBERS,
 ) : CohortStorage {
     companion object {
         val log by logger()
@@ -263,6 +271,112 @@ internal class RedisCohortStorage(
                 pipeline(updates, pipelineBatchSize)
             }
         }
+    }
+
+    /**
+     * Compute and apply the added/removed membership updates between the existing and new cohort
+     * member sets without issuing any O(cohort size) Redis command.
+     *
+     * SDIFFSTORE was previously used here, but a set difference over the full old/new member sets
+     * executes as a single blocking command on one (single-threaded) shard — multi-second for
+     * multi-million member cohorts — stalling every concurrent command on that shard for its whole
+     * duration, replicas included since they re-execute the replicated command. Instead, both sets
+     * are streamed via SSCAN in [REDIS_SCAN_CHUNK_SIZE] chunks and diffed client-side, so the
+     * largest single Redis command issued is one SSCAN page regardless of cohort size.
+     *
+     * To bound proxy memory, members are hash-partitioned into ceil(size / [diffPartitionMaxMembers])
+     * partitions and diffed one partition at a time: at most one partition of the existing set is
+     * held in memory at once, at the cost of one extra SSCAN pass over both sets per additional
+     * partition.
+     *
+     * Both keys are immutable at this point (the new set is fully written before [CohortIngestionWriter.complete],
+     * the existing set is the previously published version), but they are scanned from the primary
+     * connection to avoid misclassifying members due to replica lag on the just-written new set.
+     */
+    private suspend fun applyMembershipDiff(
+        existingCohortKey: RedisKey,
+        newCohortKey: RedisKey,
+        description: CohortDescription,
+        existingSize: Int,
+        newSize: Int,
+    ): Pair<Long, Long> {
+        val partitions = ((maxOf(existingSize, newSize, 1) - 1) / diffPartitionMaxMembers) + 1
+        val cohortIdSet = setOf(description.id)
+        var addedCount = 0L
+        var removedCount = 0L
+        for (partition in 0 until partitions) {
+            val existingPartition = HashSet<String>()
+            redis.sscanChunked(existingCohortKey, REDIS_SCAN_CHUNK_SIZE) { chunk ->
+                for (member in chunk) {
+                    if (partitions == 1 || partitionOf(member, partitions) == partition) {
+                        existingPartition.add(member)
+                    }
+                }
+            }
+            val added = mutableListOf<String>()
+            redis.sscanChunked(newCohortKey, REDIS_SCAN_CHUNK_SIZE) { chunk ->
+                for (member in chunk) {
+                    if (partitions > 1 && partitionOf(member, partitions) != partition) {
+                        continue
+                    }
+                    // Members present in both versions are drained from the existing partition
+                    // here; whatever remains after the scan is exactly this partition's removals.
+                    if (!existingPartition.remove(member)) {
+                        added.add(member)
+                        if (added.size >= REDIS_SCAN_CHUNK_SIZE) {
+                            addedCount +=
+                                flushMembershipUpdates(added, description.groupType, cohortIdSet) { updates, batchSize ->
+                                    redis.saddPipeline(updates, batchSize)
+                                }
+                        }
+                    }
+                }
+            }
+            addedCount +=
+                flushMembershipUpdates(added, description.groupType, cohortIdSet) { updates, batchSize ->
+                    redis.saddPipeline(updates, batchSize)
+                }
+            val removed = mutableListOf<String>()
+            for (member in existingPartition) {
+                removed.add(member)
+                if (removed.size >= REDIS_SCAN_CHUNK_SIZE) {
+                    removedCount +=
+                        flushMembershipUpdates(removed, description.groupType, cohortIdSet) { updates, batchSize ->
+                            redis.sremPipeline(updates, batchSize)
+                        }
+                }
+            }
+            removedCount +=
+                flushMembershipUpdates(removed, description.groupType, cohortIdSet) { updates, batchSize ->
+                    redis.sremPipeline(updates, batchSize)
+                }
+        }
+        return addedCount to removedCount
+    }
+
+    private suspend fun flushMembershipUpdates(
+        members: MutableList<String>,
+        groupType: String,
+        cohortIdSet: Set<String>,
+        pipeline: suspend (updates: List<Pair<RedisKey, Set<String>>>, batchSize: Int) -> Unit,
+    ): Long {
+        if (members.isEmpty()) return 0L
+        val updates =
+            members.map { userId ->
+                RedisKey.UserCohortMemberships(prefix, projectId, groupType, userId) to cohortIdSet
+            }
+        pipeline(updates, pipelineBatchSize)
+        val flushed = members.size.toLong()
+        members.clear()
+        return flushed
+    }
+
+    private fun partitionOf(
+        member: String,
+        partitions: Int,
+    ): Int {
+        val hash = member.hashCode() % partitions
+        return if (hash < 0) hash + partitions else hash
     }
 
     override suspend fun getCohort(cohortId: String): Cohort? {
@@ -367,51 +481,18 @@ internal class RedisCohortStorage(
                                 prev.lastModified,
                             )
 
-                        // Create temporary keys for differences - server-side operations
-                        val addedKey =
-                            RedisKey.CohortTemporary(
-                                prefix,
-                                projectId,
-                                description.id,
-                                "added_${System.currentTimeMillis()}",
-                            )
-                        val removedKey =
-                            RedisKey.CohortTemporary(
-                                prefix,
-                                projectId,
-                                description.id,
-                                "removed_${System.currentTimeMillis()}",
-                            )
                         val existingBlobKey = RedisKey.CohortBlob(prefix, projectId, description.id, prev.lastModified)
 
                         try {
-                            // Server-side set operations - no memory transfer to client!
-                            val addedCount = redis.sdiffstore(addedKey, newCohortKey, existingCohortKey)
-                            val removedCount = redis.sdiffstore(removedKey, existingCohortKey, newCohortKey)
+                            val (addedCount, removedCount) =
+                                applyMembershipDiff(existingCohortKey, newCohortKey, description, prev.size, finalSize)
                             log.info(
                                 "cohort={} diff: addedCount={}, removedCount={}",
                                 description.id,
                                 addedCount,
                                 removedCount,
                             )
-
-                            // Process added users in streamed chunks
-                            if (addedCount > 0) {
-                                processMembershipUpdates(addedKey, description.groupType, description.id) { updates, batchSize ->
-                                    redis.saddPipeline(updates, batchSize)
-                                }
-                            }
-
-                            // Process removed users in streamed chunks
-                            if (removedCount > 0) {
-                                processMembershipUpdates(removedKey, description.groupType, description.id) { updates, batchSize ->
-                                    redis.sremPipeline(updates, batchSize)
-                                }
-                            }
                         } finally {
-                            // Clean up temporary and existing keys
-                            redis.del(addedKey)
-                            redis.del(removedKey)
                             redis.expire(existingCohortKey, ttl)
                             redis.expire(existingBlobKey, ttl)
                         }

--- a/core/src/test/kotlin/cohort/CohortStorageTest.kt
+++ b/core/src/test/kotlin/cohort/CohortStorageTest.kt
@@ -205,6 +205,47 @@ class CohortStorageTest {
         }
 
     @Test
+    fun `test redis, cohort update diffs client side across partitions`(): Unit =
+        runBlocking {
+            // diffPartitionMaxMembers=3 forces multiple hash partitions for a 10-member cohort so
+            // the partitioned code path is exercised, not just the single-partition fast path.
+            val cohortStorage =
+                RedisCohortStorage(
+                    "12345",
+                    Duration.INFINITE,
+                    "amplitude ",
+                    redis,
+                    redis,
+                    1000,
+                    1000,
+                    CohortBlobCache(),
+                    diffPartitionMaxMembers = 3,
+                )
+            val v1 = cohort("p", lastModified = 1, members = (1..10).map { "u$it" }.toSet())
+            run {
+                val acc = cohortStorage.createWriter(v1.toCohortDescription())
+                acc.addMembers(v1.members.toList())
+                acc.complete(v1.members.size)
+            }
+            for (member in 1..10) {
+                assertEquals(setOf("p"), cohortStorage.getCohortMemberships("User", "u$member"))
+            }
+            // v2 removes u1-u5 and adds u11-u15
+            val v2 = cohort("p", lastModified = 2, members = (6..15).map { "u$it" }.toSet())
+            run {
+                val acc = cohortStorage.createWriter(v2.toCohortDescription())
+                acc.addMembers(v2.members.toList())
+                acc.complete(v2.members.size)
+            }
+            for (removed in 1..5) {
+                assertEquals(emptySet(), cohortStorage.getCohortMemberships("User", "u$removed"))
+            }
+            for (retained in 6..15) {
+                assertEquals(setOf("p"), cohortStorage.getCohortMemberships("User", "u$retained"))
+            }
+        }
+
+    @Test
     fun `test redis, put large cohort, no OutOfMemoryError`(): Unit =
         runBlocking {
             val cohortStorage = RedisCohortStorage("12345", Duration.INFINITE, "amplitude ", redis, redis, 1000, 1000, CohortBlobCache())


### PR DESCRIPTION
## Problem

`RedisCohortStorage` computes the added/removed members between two cohort versions with two server-side `SDIFFSTORE` calls over the full old/new member sets. A set difference is O(N) and Redis executes it as a **single atomic command on a single-threaded shard**, so for multi-million member cohorts the diff blocks that shard — and its replicas, which re-execute the replicated command — for the entire duration. Every concurrent command routed to that shard queues behind it, including the `SMEMBERS` reads that serve `/sdk/v2/memberships` requests.

Observed in a production deployment running ~10M-member cohorts (Redis Cluster, 6 shards):

- `SDIFFSTORE` p50 ~88ms, but p75 ~2s / p95 ~8s / p99 ~9.9s during periods when the large cohorts republish (hourly warehouse-import recomputes → ~2 diffs per version pickup).
- Request-path `SMEMBERS` (normally p99 ~1.4ms) showed multi-second tail stalls that correlate 1:1 with slow `SDIFFSTORE` executions — over 3 days at 10-minute resolution, every SMEMBERS stall bin had a concurrent slow SDIFFSTORE and every SDIFFSTORE >5s bin produced SMEMBERS stalls.
- At ~10M members the diff reliably crosses the default 10s Lettuce command timeout (`Default.REDIS_COMMAND_TIMEOUT_MILLIS`), so the refresh throws, the version never publishes, and the next sync cycle re-downloads and re-diffs — a retry loop that re-runs the ~10s shard block while the cohort stays stale. A client-side timeout cannot cancel the server-side execution, so tightening timeouts cannot mitigate this.

## Change

Compute the diff client-side from streamed data instead, so the largest single Redis command issued during a cohort update is one `SSCAN` page regardless of cohort size:

- `SSCAN` the existing member set in `REDIS_SCAN_CHUNK_SIZE` (1000) chunks into memory, then `SSCAN` the new set: members absent from the existing set are additions (flushed incrementally via the existing pipelined `SADD` path); members present in both are drained, so whatever remains afterward is exactly the set of removals (flushed via pipelined `SREM`).
- To bound proxy memory, members are hash-partitioned into `ceil(size / diffPartitionMaxMembers)` partitions (default 2M ⇒ at most ~2M member strings held at once, ~5 partitions for a 10M cohort) and diffed one partition at a time, at the cost of one extra `SSCAN` pass over both sets per additional partition.
- Both keys are immutable at diff time (the new set is fully written before `complete()`, the existing set is the previously published version); they are scanned from the primary connection to avoid misclassification from replica lag on the just-written new set.
- The `CohortTemporary` added/removed staging keys are no longer written.

Trade-offs: refresh wall-clock for very large cohorts increases (multiple sequential SSCAN passes instead of one blocking command) and the member data now transits to the proxy during diffing — but the refresh is a background loop, and in exchange serving latency is fully decoupled from cohort size and the diff can no longer exceed the command timeout.

## Testing

- New test exercising a version update with adds and removals across multiple hash partitions (`diffPartitionMaxMembers = 3` forces the partitioned path).
- Existing `CohortStorageTest` update/delete/membership tests pass unchanged on the new path (`:core:test` green, ktlint clean).

---

Happy to adjust the approach (e.g., gate behind a configuration flag, different partition sizing, or exposing `diffPartitionMaxMembers` via `RedisConfiguration`) if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core cohort publish semantics and Redis load patterns for every version update; incorrect diff logic would corrupt user cohort memberships, though behavior is covered by existing and new tests.
> 
> **Overview**
> **Cohort version updates** no longer run two full-set `SDIFFSTORE` calls (and temporary added/removed keys). `RedisCohortStorage` now diffs old vs new member sets by streaming both cohort keys with `SSCAN`, computing adds/removals in the proxy, and applying them through the existing pipelined `SADD` / `SREM` membership paths.
> 
> Large cohorts are handled in **hash partitions** (default cap ~2M members per partition via `diffPartitionMaxMembers`) so only one partition of the prior version is held in memory at a time, at the cost of extra `SSCAN` passes. Diff scans use the **primary** Redis connection so replica lag does not misclassify members on the just-written new set.
> 
> A new test forces a small partition size to verify adds and removals across the multi-partition code path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b733a440db18cccb24042c1b544d54cb9a913214. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->