### PR TITLE
Add cohort_streamed_diff_enabled input to perf test workflow

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -10,6 +10,11 @@ on:
         description: 'Git SHA to build (defaults to current HEAD)'
         required: false
         type: string
+      cohort_streamed_diff_enabled:
+        description: 'Set AMPLITUDE_COHORT_STREAMED_DIFF_ENABLED=true on the perf-test deployment'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   trigger-sdk-tests:
@@ -27,6 +32,15 @@ jobs:
             echo "sha=${{ github.event.inputs.sha }}" >> $GITHUB_OUTPUT
           else
             echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Get cohort streamed diff flag
+        id: get-flag
+        run: |
+          if [ "${{ github.event.inputs.cohort_streamed_diff_enabled }}" = "true" ]; then
+            echo "cohort_streamed_diff_enabled=true" >> $GITHUB_OUTPUT
+          else
+            echo "cohort_streamed_diff_enabled=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Generate GitHub App token
@@ -49,7 +63,8 @@ jobs:
                 "ref": "${{ github.ref }}",
                 "repo_url": "${{ github.repositoryUrl }}",
                 "triggered_by": "${{ github.actor }}",
-                "workflow_run_id": "${{ github.run_id }}"
+                "workflow_run_id": "${{ github.run_id }}",
+                "cohort_streamed_diff_enabled": "${{ steps.get-flag.outputs.cohort_streamed_diff_enabled }}"
               }
             }'
 
@@ -60,5 +75,6 @@ jobs:
           echo "- **SHA**: ${{ steps.get-sha.outputs.sha }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Ref**: ${{ github.ref }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Triggered by**: ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Cohort streamed diff enabled**: ${{ steps.get-flag.outputs.cohort_streamed_diff_enabled }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Check the [sdk-tests workflow runs](https://github.com/amplitude/sdk-tests/actions) for build progress." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -27,20 +27,25 @@ jobs:
 
       - name: Get commit SHA
         id: get-sha
+        env:
+          INPUT_SHA: ${{ github.event.inputs.sha }}
+          HEAD_SHA: ${{ github.sha }}
         run: |
-          if [ -n "${{ github.event.inputs.sha }}" ]; then
-            echo "sha=${{ github.event.inputs.sha }}" >> $GITHUB_OUTPUT
+          if [ -n "$INPUT_SHA" ]; then
+            echo "sha=$INPUT_SHA" >> "$GITHUB_OUTPUT"
           else
-            echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+            echo "sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Get cohort streamed diff flag
         id: get-flag
+        env:
+          COHORT_STREAMED_DIFF_ENABLED: ${{ github.event.inputs.cohort_streamed_diff_enabled }}
         run: |
-          if [ "${{ github.event.inputs.cohort_streamed_diff_enabled }}" = "true" ]; then
-            echo "cohort_streamed_diff_enabled=true" >> $GITHUB_OUTPUT
+          if [ "$COHORT_STREAMED_DIFF_ENABLED" = "true" ]; then
+            echo "cohort_streamed_diff_enabled=true" >> "$GITHUB_OUTPUT"
           else
-            echo "cohort_streamed_diff_enabled=false" >> $GITHUB_OUTPUT
+            echo "cohort_streamed_diff_enabled=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Generate GitHub App token
@@ -51,30 +56,53 @@ jobs:
           application_private_key: ${{ secrets.EVALUATION_PROXY_INTEGRATION_KEY }}
 
       - name: Trigger sdk-tests workflow
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          SHA: ${{ steps.get-sha.outputs.sha }}
+          REF: ${{ github.ref }}
+          REPO_URL: ${{ github.repositoryUrl }}
+          TRIGGERED_BY: ${{ github.actor }}
+          WORKFLOW_RUN_ID: ${{ github.run_id }}
+          COHORT_STREAMED_DIFF_ENABLED: ${{ steps.get-flag.outputs.cohort_streamed_diff_enabled }}
         run: |
-          curl -X POST \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token ${{ steps.generate-token.outputs.token }}" \
-            https://api.github.com/repos/amplitude/sdk-tests/dispatches \
-            -d '{
-              "event_type": "evaluation-proxy-tests",
-              "client_payload": {
-                "sha": "${{ steps.get-sha.outputs.sha }}",
-                "ref": "${{ github.ref }}",
-                "repo_url": "${{ github.repositoryUrl }}",
-                "triggered_by": "${{ github.actor }}",
-                "workflow_run_id": "${{ github.run_id }}",
-                "cohort_streamed_diff_enabled": "${{ steps.get-flag.outputs.cohort_streamed_diff_enabled }}"
+          jq -n \
+            --arg sha "$SHA" \
+            --arg ref "$REF" \
+            --arg repo_url "$REPO_URL" \
+            --arg triggered_by "$TRIGGERED_BY" \
+            --arg workflow_run_id "$WORKFLOW_RUN_ID" \
+            --arg cohort_streamed_diff_enabled "$COHORT_STREAMED_DIFF_ENABLED" \
+            '{
+              event_type: "evaluation-proxy-tests",
+              client_payload: {
+                sha: $sha,
+                ref: $ref,
+                repo_url: $repo_url,
+                triggered_by: $triggered_by,
+                workflow_run_id: $workflow_run_id,
+                cohort_streamed_diff_enabled: $cohort_streamed_diff_enabled
               }
-            }'
+            }' \
+          | curl -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${GH_TOKEN}" \
+            https://api.github.com/repos/amplitude/sdk-tests/dispatches \
+            -d @-
 
       - name: Output summary
+        env:
+          SHA: ${{ steps.get-sha.outputs.sha }}
+          REF: ${{ github.ref }}
+          TRIGGERED_BY: ${{ github.actor }}
+          COHORT_STREAMED_DIFF_ENABLED: ${{ steps.get-flag.outputs.cohort_streamed_diff_enabled }}
         run: |
-          echo "## Triggered SDK Tests" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **SHA**: ${{ steps.get-sha.outputs.sha }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Ref**: ${{ github.ref }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Triggered by**: ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Cohort streamed diff enabled**: ${{ steps.get-flag.outputs.cohort_streamed_diff_enabled }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Check the [sdk-tests workflow runs](https://github.com/amplitude/sdk-tests/actions) for build progress." >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Triggered SDK Tests"
+            echo ""
+            echo "- **SHA**: $SHA"
+            echo "- **Ref**: $REF"
+            echo "- **Triggered by**: $TRIGGERED_BY"
+            echo "- **Cohort streamed diff enabled**: $COHORT_STREAMED_DIFF_ENABLED"
+            echo ""
+            echo "Check the [sdk-tests workflow runs](https://github.com/amplitude/sdk-tests/actions) for build progress."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Adds a `cohort_streamed_diff_enabled` boolean input (default false) to the manual perf test workflow, forwarded in the `repository_dispatch` payload to amplitude/sdk-tests, which passes it to the deploy repo so `AMPLITUDE_COHORT_STREAMED_DIFF_ENABLED` (added in #40, default false) is set on the stage2 perf-test deployment in the same commit as the image tag.

- Manual run with the box checked → deployment gets `AMPLITUDE_COHORT_STREAMED_DIFF_ENABLED=true` for that perf run.
- Manual run with the box unchecked, or any push to main → flag is explicitly reset to `false`.

**Merge order:** amplitude/deploy#23810 → amplitude/sdk-tests#6 → this PR.

Note: the flag is a runtime no-op until #40 merges; to perf-test #40 now, run this workflow from this branch and pass the #40 commit as the `sha` input.

## Testing

- actionlint: no new finding classes vs the base file (new steps follow the file's existing $GITHUB_OUTPUT idiom).
- Payload JSON validity and end-to-end chain (flag=true / flag=false / push-to-main / legacy consumers) verified against the sdk-tests and deploy changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes with no application runtime impact; risk is limited to incorrect dispatch payload wiring for perf-test deployments.
> 
> **Overview**
> Adds a **`workflow_dispatch`** boolean input **`cohort_streamed_diff_enabled`** (default **false**) so manual perf runs can turn on **`AMPLITUDE_COHORT_STREAMED_DIFF_ENABLED`** on the stage2 perf-test deployment via the downstream chain.
> 
> A new step normalizes that input to **`true`/`false`** (including push-to-main and unchecked manual runs as **false**) and includes **`cohort_streamed_diff_enabled`** in the **`repository_dispatch`** **`client_payload`** to **amplitude/sdk-tests**. The job summary now prints the flag value.
> 
> Shell steps were tightened to pass values through **`env`** instead of inline **`${{ }}`** in scripts, and the dispatch body is built with **`jq`** piped to **`curl`** instead of an inline JSON string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86010d66ae61e45d36c9751713a205a62aaf1e4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->