### PR TITLE
Fix: update gh token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Commit Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PUBLISH_TOKEN }}
           GIT_AUTHOR_NAME: amplitude-sdk-bot
           GIT_AUTHOR_EMAIL: amplitude-sdk-bot@users.noreply.github.com
           GIT_COMMITTER_NAME: amplitude-sdk-bot

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
 
       - name: Set up Java 17
         uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
@@ -105,12 +107,13 @@ jobs:
 
       - name: Commit Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PUBLISH_TOKEN }}
+          GH_PUBLISH_TOKEN: ${{ secrets.GH_PUBLISH_TOKEN }}
           GIT_AUTHOR_NAME: amplitude-sdk-bot
           GIT_AUTHOR_EMAIL: amplitude-sdk-bot@users.noreply.github.com
           GIT_COMMITTER_NAME: amplitude-sdk-bot
           GIT_COMMITTER_EMAIL: amplitude-sdk-bot@users.noreply.github.com
         run: |
+          git remote set-url origin "https://x-access-token:${GH_PUBLISH_TOKEN}@github.com/${{ github.repository }}"
           git commit -am "release: ${{ github.event.inputs.version }}"
           git tag v${{ github.event.inputs.version }}
           git push

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -108,13 +108,16 @@ jobs:
       - name: Commit Release
         env:
           GH_PUBLISH_TOKEN: ${{ secrets.GH_PUBLISH_TOKEN }}
+          VERSION: ${{ github.event.inputs.version }}
           GIT_AUTHOR_NAME: amplitude-sdk-bot
           GIT_AUTHOR_EMAIL: amplitude-sdk-bot@users.noreply.github.com
           GIT_COMMITTER_NAME: amplitude-sdk-bot
           GIT_COMMITTER_EMAIL: amplitude-sdk-bot@users.noreply.github.com
         run: |
-          git remote set-url origin "https://x-access-token:${GH_PUBLISH_TOKEN}@github.com/${{ github.repository }}"
-          git commit -am "release: ${{ github.event.inputs.version }}"
-          git tag v${{ github.event.inputs.version }}
+          git config --local http.https://github.com/.extraheader \
+            "AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_PUBLISH_TOKEN" | base64 -w0)"
+          git commit -am "release: ${VERSION}"
+          git tag "v${VERSION}"
           git push
           git push --tags
+          git config --local --unset-all http.https://github.com/.extraheader


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes release automation credentials and git push behavior; a misconfigured or under-scoped GH_PUBLISH_TOKEN could break releases or grant broader repo write access than intended.
> 
> **Overview**
> Updates the **release** workflow so release commits and tags are pushed with a dedicated **`GH_PUBLISH_TOKEN`** instead of the default **`GITHUB_TOKEN`**.
> 
> Checkout now sets **`persist-credentials: false`**, and the **Commit Release** step configures a temporary GitHub HTTP **`Authorization`** header from **`GH_PUBLISH_TOKEN`** before **`git push`** / **`git push --tags`**, then removes it. Release commit/tag messaging is driven via a **`VERSION`** env var (same input as before).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9eff25e92c206e3d3da11da5cd70b72db0abecb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->