### PR TITLE
fix: publish release images to ECR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
 
       # SETUP & VALIDATION
@@ -78,11 +81,14 @@ jobs:
 
       # RELEASE DOCKER IMAGE
 
-      - name: Login to DockerHub
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
+      - name: Configure AWS credentials
+        uses: amplitude/actions/configure-aws-credentials@v0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          account: ops
+
+      - name: Log in to Amazon ECR
+        id: login-ecr
+        uses: amplitude/actions/amazon-ecr-login@v0
 
       - name: Get Build Date
         run: |
@@ -93,10 +99,10 @@ jobs:
         uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4
         with:
           tags: type=semver,pattern={{version}},value=v${{ github.event.inputs.version }}
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/evaluation-proxy
+          images: ${{ steps.login-ecr.outputs.registry }}/evaluation-proxy
 
       - name: Docker Build and Push
-        uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # v3
+        uses: amplitude/actions/build-push-action@v0
         with:
           context: .
           push: true


### PR DESCRIPTION
## Summary

- replace the expired DockerHub PAT login with short-lived GitHub OIDC credentials for the ops AWS account
- publish semantic-versioned release images to the ops ECR registry returned by the ECR login action
- use Amplitude's AWS credential, ECR login, and Buildx wrapper actions
- keep ECR repository ownership in `amplitude/deploy`; the release workflow only references the `evaluation-proxy` repository name

## Publishing flow

`evaluation-proxy` release → ops ECR `evaluation-proxy` → platform ECR-to-DockerHub sync → `amplitudeinc/evaluation-proxy`

The repository is already declared by [`createRepo: true` in `amplitude/deploy`](https://github.com/amplitude/deploy/blob/master/workflows/evaluation-proxy/ops/evaluation-proxy-stage2.yaml#L141). This PR does not duplicate that infrastructure definition or expose DockerHub credentials to the GitHub Actions runner.

## Validation

- `./gradlew ktlintCheck test`
- parsed `.github/workflows/release.yaml` as YAML
- `git diff --check`
- confirmed the referenced failed release stopped at DockerHub login because its PAT had expired

## Platform dependencies

- the ops OIDC role `gha-evaluation-proxy-release` must have push access to the ECR repository
- the isolated sync service must map ECR `evaluation-proxy` to DockerHub `amplitudeinc/evaluation-proxy` and preserve the semantic-version tag

Application runtime code is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release pipeline's auth and image destination; a misconfigured OIDC role or ECR repo would block releases until fixed, but application runtime code is untouched.
>
> **Overview**
> **Release workflow** no longer logs into Docker Hub with a PAT. It now requests **`id-token: write`** (and **`contents: read`**) so the job can assume AWS credentials in the **ops** account, log into **Amazon ECR**, and push semver-tagged **`evaluation-proxy`** images to the ECR registry from the login step.
>
> Docker image metadata and push use **`${{ steps.login-ecr.outputs.registry }}/evaluation-proxy`** instead of **`DOCKERHUB_USERNAME/evaluation-proxy`**, and the build/push step switches to Amplitude's **`configure-aws-credentials`**, **`amazon-ecr-login`**, and **`build-push-action`** wrappers.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd5573a438f680db3e0fa2e24e3a2b3cceb0a20c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
